### PR TITLE
Bugfix for storing new gig with key `nil` in `giggin.state/upsert-gig`

### DIFF
--- a/increments/17-refactor-gigs/src/giggin/components/gigs.cljs
+++ b/increments/17-refactor-gigs/src/giggin/components/gigs.cljs
@@ -15,12 +15,13 @@
                        (swap! modal assoc :active active)
                        (reset! values gig))
         upsert-gig (fn [{:keys [id title desc price img sold-out]}]
-                     (swap! state/gigs assoc id {:id (or id (str "gig-" (random-uuid)))
-                                                 :title (str/trim title)
-                                                 :desc (str/trim desc)
-                                                 :img (str/trim img)
-                                                 :price (js/parseInt price)
-                                                 :sold-out sold-out})
+                     (let [id (or id (str "gig-" (random-uuid)))]
+                       (swap! state/gigs assoc id {:id id
+                                                   :title (str/trim title)
+                                                   :desc (str/trim desc)
+                                                   :img (str/trim img)
+                                                   :price (js/parseInt price)
+                                                   :sold-out sold-out}))
                      (toggle-modal {:active false :gig {}}))]
     (fn
       []

--- a/increments/18-ajax-requests/src/giggin/components/gigs.cljs
+++ b/increments/18-ajax-requests/src/giggin/components/gigs.cljs
@@ -16,12 +16,13 @@
                        (swap! modal assoc :active active)
                        (reset! values gig))
         upsert-gig (fn [{:keys [id title desc price img sold-out]}]
-                     (swap! state/gigs assoc id {:id (or id (str "gig-" (random-uuid)))
-                                                 :title (str/trim title)
-                                                 :desc (str/trim desc)
-                                                 :img (str/trim img)
-                                                 :price (js/parseInt price)
-                                                 :sold-out sold-out})
+                     (let [id (or id (str "gig-" (random-uuid)))]
+                       (swap! state/gigs assoc id {:id id
+                                                   :title (str/trim title)
+                                                   :desc (str/trim desc)
+                                                   :img (str/trim img)
+                                                   :price (js/parseInt price)
+                                                   :sold-out sold-out}))
                      (toggle-modal {:active false :gig initial-values}))]
     (fn
       []

--- a/increments/19-ajax-transformations/src/giggin/components/gigs.cljs
+++ b/increments/19-ajax-transformations/src/giggin/components/gigs.cljs
@@ -16,12 +16,13 @@
                        (swap! modal assoc :active active)
                        (reset! values gig))
         upsert-gig (fn [{:keys [id title desc price img sold-out]}]
-                     (swap! state/gigs assoc id {:id (or id (str "gig-" (random-uuid)))
-                                                 :title (str/trim title)
-                                                 :desc (str/trim desc)
-                                                 :img (str/trim img)
-                                                 :price (js/parseInt price)
-                                                 :sold-out sold-out})
+                     (let [id (or id (str "gig-" (random-uuid)))]
+                       (swap! state/gigs assoc id {:id id
+                                                   :title (str/trim title)
+                                                   :desc (str/trim desc)
+                                                   :img (str/trim img)
+                                                   :price (js/parseInt price)
+                                                   :sold-out sold-out}))
                      (toggle-modal {:active false :gig initial-values}))]
     (fn
       []

--- a/increments/20-firebase-setup/src/giggin/components/gigs.cljs
+++ b/increments/20-firebase-setup/src/giggin/components/gigs.cljs
@@ -16,12 +16,13 @@
                        (swap! modal assoc :active active)
                        (reset! values gig))
         upsert-gig (fn [{:keys [id title desc price img sold-out]}]
-                     (swap! state/gigs assoc id {:id (or id (str "gig-" (random-uuid)))
-                                                 :title (str/trim title)
-                                                 :desc (str/trim desc)
-                                                 :img (str/trim img)
-                                                 :price (js/parseInt price)
-                                                 :sold-out sold-out})
+                     (let [id (or id (str "gig-" (random-uuid)))]
+                       (swap! state/gigs assoc id {:id id
+                                                   :title (str/trim title)
+                                                   :desc (str/trim desc)
+                                                   :img (str/trim img)
+                                                   :price (js/parseInt price)
+                                                   :sold-out sold-out}))
                      (toggle-modal {:active false :gig initial-values}))]
     (fn
       []

--- a/increments/21-firebase-database/src/giggin/components/gigs.cljs
+++ b/increments/21-firebase-database/src/giggin/components/gigs.cljs
@@ -16,12 +16,13 @@
                        (swap! modal assoc :active active)
                        (reset! values gig))
         upsert-gig (fn [{:keys [id title desc price img sold-out]}]
-                     (swap! state/gigs assoc id {:id (or id (str "gig-" (random-uuid)))
-                                                 :title (str/trim title)
-                                                 :desc (str/trim desc)
-                                                 :img (str/trim img)
-                                                 :price (js/parseInt price)
-                                                 :sold-out sold-out})
+                     (let [id (or id (str "gig-" (random-uuid)))]
+                       (swap! state/gigs assoc id {:id id
+                                                   :title (str/trim title)
+                                                   :desc (str/trim desc)
+                                                   :img (str/trim img)
+                                                   :price (js/parseInt price)
+                                                   :sold-out sold-out}))
                      (toggle-modal {:active false :gig initial-values}))]
     (fn
       []

--- a/increments/22-subscribe/src/giggin/components/gigs.cljs
+++ b/increments/22-subscribe/src/giggin/components/gigs.cljs
@@ -16,12 +16,13 @@
                        (swap! modal assoc :active active)
                        (reset! values gig))
         upsert-gig (fn [{:keys [id title desc price img sold-out]}]
-                     (swap! state/gigs assoc id {:id (or id (str "gig-" (random-uuid)))
-                                                 :title (str/trim title)
-                                                 :desc (str/trim desc)
-                                                 :img (str/trim img)
-                                                 :price (js/parseInt price)
-                                                 :sold-out sold-out})
+                     (let [id (or id (str "gig-" (random-uuid)))]
+                       (swap! state/gigs assoc id {:id id
+                                                   :title (str/trim title)
+                                                   :desc (str/trim desc)
+                                                   :img (str/trim img)
+                                                   :price (js/parseInt price)
+                                                   :sold-out sold-out}))
                      (toggle-modal {:active false :gig initial-values}))]
     (fn
       []


### PR DESCRIPTION
@jacekschae 
Here is a bugfix, which you eventually did in video 22 of your great course.

Without the `id` in the `let` `upsert-gig` will assoc a new gig with the key `nil` into `state/gigs`.
This will lead to strange behaviour. You can apparently successfully create a new gig in the app. But when you edit the newly created gig and save again, this new gig will appear a second time in the app. The edits to the first gig (with the nil key) will not get stored in this gig but in the duplicate second gig with the correct uuid-key.

It confused me. I hope this fix could help future learners!