### PR TITLE
Update shadow-cljs version to fix the build on JDK 15+.

### DIFF
--- a/giggin/package.json
+++ b/giggin/package.json
@@ -11,7 +11,7 @@
     "clean-win": "rmdir /s /q public/js & rmdir /s /q target"
   },
   "devDependencies": {
-    "shadow-cljs": "2.8.52"
+    "shadow-cljs": "2.11.23"
   },
   "dependencies": {
     "create-react-class": "15.6.3",

--- a/giggin/package.json
+++ b/giggin/package.json
@@ -14,8 +14,8 @@
     "shadow-cljs": "2.11.23"
   },
   "dependencies": {
-    "create-react-class": "15.6.3",
-    "react": "16.3.2",
-    "react-dom": "16.3.2"
+    "create-react-class": "15.7.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }


### PR DESCRIPTION
This fixes: https://github.com/jacekschae/learn-reagent-course-files/issues/17

"Cannot invoke \"Object.getClass()\" because \"target\" is null" see this: https://clojurians-log.clojureverse.org/shadow-cljs/2021-03-26
The problem is with a _very_ outdated shadow-cljs version which doesn't work with JDK15+

See also [Warning: Nashorn engine is planned to be removed from a future JDK release #441](https://github.com/thheller/shadow-cljs/issues/441)

This also updates (unrelated) react versions to get them to the latest version and fix npm install/audit warnings.