### PR TITLE
fixed default generated id for new gig

### DIFF
--- a/increments/18-ajax-requests/src/giggin/components/gigs.cljs
+++ b/increments/18-ajax-requests/src/giggin/components/gigs.cljs
@@ -16,13 +16,14 @@
                        (swap! modal assoc :active active)
                        (reset! values gig))
         upsert-gig (fn [{:keys [id title desc price img sold-out]}]
-                     (swap! state/gigs assoc id {:id (or id (str "gig-" (random-uuid)))
-                                                 :title (str/trim title)
-                                                 :desc (str/trim desc)
-                                                 :img (str/trim img)
-                                                 :price (js/parseInt price)
-                                                 :sold-out sold-out})
-                     (toggle-modal {:active false :gig initial-values}))]
+                     (let [id (or id (str "gig-" (random-uuid)))]
+                       (swap! state/gigs assoc (keyword id) {:id id
+                                                             :title (str/trim title)
+                                                             :desc (str/trim desc)
+                                                             :img (str/trim img)
+                                                             :price (js/parseInt price)
+                                                             :sold-out sold-out})
+                       (toggle-modal {:active false :gig initial-values})))]
     (fn
       []
       [:main


### PR DESCRIPTION
This PR is to fix an issue that I found while working on the tutorial in chapter 17 during the refactoring.

I'm not sure if this issue is picked up subseqently in the downstream chapters as I am only halfway through.

The main issue is on the upsert-gig function. In it's current state, the state/gig atom will use a nil key when adding a new gig as it is only defined later in the gig map as shown like this.
![image](https://user-images.githubusercontent.com/42490433/209743509-182134c6-df30-4b0d-94e4-b5105fdd3307.png)
You can see that the key is nil as is expected

The next thing is to keywordise to conform with the current state/gig atom formatting otherwise the key will be a string.

With the setup done
![image](https://user-images.githubusercontent.com/42490433/209744822-44ba77fd-a549-4f4d-824d-fb1095128e73.png)

Do let me know how you would like to proceed with the changes in the downstream increment if you would like to merge it